### PR TITLE
fix: switch global AMI type to alinux2

### DIFF
--- a/distro-on-eks/README.md
+++ b/distro-on-eks/README.md
@@ -156,7 +156,7 @@ The Kubernetes section of the `furyctl.yaml` file contains the following paramet
 
 ```yaml
   kubernetes:
-    nodePoolGlobalAmiType: alinux2023
+    nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: "launch_templates"
     nodeAllowedSshPublicKey: "{file:///path/to/id_rsa.pub}"
     logRetentionDays: 1

--- a/distro-on-eks/furyctl.yaml
+++ b/distro-on-eks/furyctl.yaml
@@ -48,7 +48,7 @@ spec:
         allowedFromCidrs:
           - 0.0.0.0/0
   kubernetes:
-    nodePoolGlobalAmiType: alinux2023
+    nodePoolGlobalAmiType: alinux2
     nodePoolsLaunchKind: "launch_templates"
     nodeAllowedSshPublicKey: "{file:///path/to/id_rsa.pub}"
     logRetentionDays: 1


### PR DESCRIPTION
### Summary 💡

Amazon Linux 2023-based EKS AMIs [deprecated bootstrap.sh](https://awslabs.github.io/amazon-eks-ami/nodeadm/), replacing it with the new nodeadm system for node initialization. This broke self-managed node pools relying on bootstrap.sh.

Closes: [#650](https://github.com/sighupio/product-management/issues/650)

### Description 📝

This PR applies a temporary fix by switching the global AMI type back to alinux2.

### Breaking Changes 💔

None.

### Tests performed 🧪

Example:

- [x] Tested a clean installation with SD version 1.31.1 on EKS.

### Future work 🔧

Reintroduce AL2023 support once nodeadm-based user data handling will be integrate into our installer.