### PR TITLE
chore: align guides with Immutable

### DIFF
--- a/distro-on-eks/README.md
+++ b/distro-on-eks/README.md
@@ -342,6 +342,12 @@ To interact with the cluster a `kubeconfig` has been created on the folder, make
 export KUBECONFIG=$PWD/kubeconfig
 ```
 
+To see a summary of the cluster, you can run `furyctl get cluster-info`. It shows the SD version and kind, the installer version, the available upgrade paths, the Kubernetes version, and the installed modules and plugins. Add `--format json` or `--format yaml` for a machine-readable output.
+
+```bash
+furyctl get cluster-info
+```
+
 ## Step 3 - Explore the SIGHUP Distribution
 
 ### Setup local DNS
@@ -541,7 +547,9 @@ We hope you enjoyed this tour of SIGHUP Distribution!
 
 ### Issues/Feedback
 
-In case you ran into any problems feel free to [open an issue in GitHub](https://github.com/sighupio/getting-started/issues/new).
+In case you ran into any problems with this tutorial, feel free to [open an issue in the getting-started repository](https://github.com/sighupio/getting-started/issues/new).
+
+If the installation itself failed, please [open an issue in the SIGHUP Distribution repository](https://github.com/sighupio/distribution/issues/new/choose) instead: it has issue templates, and its maintainers triage the components installed here.
 
 ### Where to go next?
 

--- a/distro-on-minikube/README.md
+++ b/distro-on-minikube/README.md
@@ -191,6 +191,12 @@ INFO Saving distribution configuration file in the cluster...
 
 🚀 The (subset of the) distribution is finally deployed! In this section you will explore some of its features.
 
+To see a summary of the cluster, you can run `furyctl get cluster-info`. It shows the SD version and kind, the installer version, the available upgrade paths, the Kubernetes version, and the installed modules and plugins. Add `--format json` or `--format yaml` for a machine-readable output.
+
+```bash
+furyctl get cluster-info
+```
+
 ## Step 4 - Explore the distribution
 
 ### Setup local DNS
@@ -290,7 +296,9 @@ We hope you enjoyed this tour of SIGHUP Distribution!
 
 ### Issues/Feedback
 
-In case you ran into any problems feel free to [open an issue in GitHub](https://github.com/sighupio/getting-started/issues/new).
+In case you ran into any problems with this tutorial, feel free to [open an issue in the getting-started repository](https://github.com/sighupio/getting-started/issues/new).
+
+If the installation itself failed, please [open an issue in the SIGHUP Distribution repository](https://github.com/sighupio/distribution/issues/new/choose) instead: it has issue templates, and its maintainers triage the components installed here.
 
 ### Where to go next?
 

--- a/distro-on-vms/README.md
+++ b/distro-on-vms/README.md
@@ -504,6 +504,12 @@ To interact with the cluster a `kubeconfig` has been created on the folder, make
 export KUBECONFIG=$PWD/kubeconfig
 ```
 
+To see a summary of the cluster, you can run `furyctl get cluster-info`. It shows the SD version and kind, the installer version, the available upgrade paths, the Kubernetes version, and the installed modules and plugins. Add `--format json` or `--format yaml` for a machine-readable output.
+
+```bash
+furyctl get cluster-info
+```
+
 ## Step 6 - Explore the distribution
 
 ### Forecastle
@@ -552,7 +558,9 @@ We hope you enjoyed this tour of SIGHUP Distribution!
 
 ### Issues/Feedback
 
-In case you ran into any problems, feel free to [open an issue in GitHub](https://github.com/sighupio/getting-started/issues/new).
+In case you ran into any problems with this tutorial, feel free to [open an issue in the getting-started repository](https://github.com/sighupio/getting-started/issues/new).
+
+If the installation itself failed, please [open an issue in the SIGHUP Distribution repository](https://github.com/sighupio/distribution/issues/new/choose) instead: it has issue templates, and its maintainers triage the components installed here.
 
 ### Where to go next?
 


### PR DESCRIPTION
Align the rest of the guides with the latest changes introduced with the Immutable guide:

- Mention `furyctl get cluster-info` command
- Point readers to the distribution repo for opening issues

Note:
I've updated the shared screenshots for Grafana in the `media` branch.

Relates:
- https://github.com/sighupio/getting-started/pull/81